### PR TITLE
Fix issues introduced by encoded body scrubbing

### DIFF
--- a/lib/Catalyst/Plugin/HTML/Scrubber.pm
+++ b/lib/Catalyst/Plugin/HTML/Scrubber.pm
@@ -48,9 +48,13 @@ sub html_scrub {
     my ($c, $conf) = @_;
 
     # If there's body_data - for e.g. a POSTed JSON body that was decoded -
-    # then we need to walk through it, scrubbing as appropriate
-    if (my $body_data = $c->request->body_data) {
-	$c->_scrub_recurse($conf, $c->request->body_data);
+    # then we need to walk through it, scrubbing as appropriate; don't call
+    # body_data unless the content type is one there's a data handler for
+    # though, otherwise we'll trigger an exception (see GH#4)
+    if (exists $c->req->data_handlers->{ $c->req->content_type }) {
+        if (my $body_data = $c->request->body_data) {
+            $c->_scrub_recurse($conf, $c->request->body_data);
+        }
     }
 
     # And if Catalyst::Controller::REST is in use so we have $req->data,

--- a/lib/Catalyst/Plugin/HTML/Scrubber.pm
+++ b/lib/Catalyst/Plugin/HTML/Scrubber.pm
@@ -82,22 +82,22 @@ sub _scrub_recurse {
             # OK, it's fine to fettle with this key - if its value is
             # a ref, recurse, otherwise, scrub
             if (my $ref = ref $data->{$key}) {
-                $c->_scrub_recurse($conf, $data->{$key});
+                $c->_scrub_recurse($conf, $data->{$key})
+                    if defined $data->{$key};
             } else {
                 # Alright, non-ref value, so scrub it
                 # FIXME why did we have to have this ref-ref handling fun?
                 #$_ = $c->_scrubber->scrub($_) for (ref($$value) ? @{$$value} : $$value);
-                $data->{$key} = $c->_scrubber->scrub($data->{$key});
+                $data->{$key} = $c->_scrubber->scrub($data->{$key})
+                    if defined $data->{$key};
             }
         }
     } elsif (ref $data eq 'ARRAY') {
-        # Simple - scrub all the values
-        $_ = $c->_scrubber->scrub($_) for @$data;
         for (@$data) {
             if (ref $_) {
                 $c->_scrub_recurse($conf, $_);
             } else {
-                $_ = $c->_scrubber->scrub($_);
+                $_ = $c->_scrubber->scrub($_) if defined $_;
             }
         }
     } elsif (ref $data eq 'CODE') {

--- a/t/lib/MyApp03/Controller/Root.pm
+++ b/t/lib/MyApp03/Controller/Root.pm
@@ -13,5 +13,10 @@ sub index : Path : Args(0) {
     $c->res->body('index');
 }
 
+sub upload : Local : Args(0) {
+    my ($self, $c) = @_;
+    $c->res->body("Uploaded file content: " . $c->req->upload('myfile')->slurp);
+}
+
 1;
 


### PR DESCRIPTION
Fix the issues in #4 

- Don't attempt to scrub undefined values
- Don't call `$c->req->body_data` unless there's a data handler for the request content type, or we'll cause an exception
- Tests for multi-part file uploads - ensure file content is left unmolested, but any other form parameters are still scrubbed