### PR TITLE
Support not encoding HTML entities

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Catalyst::Plugin::HTML::Scrubber
 
 {{$NEXT}}
+- Bugfixes for encoded body processing - GH#4
 
 0.04   2023-09-18
 - Recursively scrub parameters in encoded PUT/POST bodies (e.g. JSON)

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension Catalyst::Plugin::HTML::Scrubber
 
 {{$NEXT}}
+
+0.05   2023-09-19
 - Bugfixes for encoded body processing - GH#4
 
 0.04   2023-09-18

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Catalyst::Plugin::HTML::Scrubber
 
 {{$NEXT}}
+- Add no_encode_entities option to skip encoding HTML entities
 
 0.05   2023-09-19
 - Bugfixes for encoded body processing - GH#4

--- a/dist.ini
+++ b/dist.ini
@@ -4,7 +4,7 @@ license = Perl_5
 copyright_holder = David Precious
 copyright_year   = 2023
 
-version = 0.04
+version = 0.05
 
 [@Basic]
 [AutoPrereqs]

--- a/t/03_params.t
+++ b/t/03_params.t
@@ -130,5 +130,29 @@ JSON
     );
 
 }
+{
+    my $req = POST('/', [foo => '>= 3']);
+    my ($res, $c) = ctx_request($req);
+    is($res->code, RC_OK, 'response ok');
+    is(
+        $c->req->param('foo'),
+        '&gt;= 3',
+        'HTML entities are encoded by default',
+    );
+
+    # Now flip on no_encode_entities and check that HTML entities are
+    # no longer encoded...
+    MyApp03->config->{scrubber}{no_encode_entities}++;
+    ($res, $c) = ctx_request($req);
+    is($res->code, RC_OK, 'response ok');
+    is(
+        $c->req->param('foo'), 
+        '>= 3',
+        'no_encode_entities works - no HTML entity encoding',
+    );
+}
+
+
+
 done_testing();
 


### PR DESCRIPTION
[HTML::Scrubber](https://metacpan.org/pod/HTML::Scrubber) will HTML-encode certain entities, e.g. angle brackets - for e.g. `foo > 4` would become `foo &gt; 4`; this may cause problems if you are not expecting that, and just wanted actual HTML to be scrubbed.

Setting `no_encode_entities` to `1` will cause us to automatically decode using `HTML::Entities::decode_entities()` to avoid that.

