### PR TITLE
Add ignore_values option to whitelist values by pattern match

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension Catalyst::Plugin::HTML::Scrubber
 
 {{$NEXT}}
+- Support exempting from scrubbing by pattern match on value
+  via new ignore_values option - PR #8 (bigpresh)
 
 0.07   2023-10-02
 - Support exempting from scrubbing based on URL path

--- a/lib/Catalyst/Plugin/HTML/Scrubber.pm
+++ b/lib/Catalyst/Plugin/HTML/Scrubber.pm
@@ -83,7 +83,7 @@ sub _scrub_recurse {
     # whether we should ignore, otherwise, do the needful
     if (ref $data eq 'HASH') {
         for my $key (keys %$data) {
-            if (!$c->_should_scrub_param($conf, $key)) {
+            if (!$c->_should_scrub_param($conf, $key, $data->{$key})) {
                 next;
             }
 
@@ -111,9 +111,12 @@ sub _scrub_recurse {
     } elsif (ref $data eq 'CODE') {
         $c->log->debug("Can't scrub a coderef!");
     } else {
-        # This shouldn't happen, as we should always start with a ref,
-        # and non-ref hash/array values should have been handled above.
-        $c->log->debug("Non-ref to scrub - should this happen?");
+        # Note that at this point we don't know what the param was called
+        # as we'll have called ourself with the value, but that's fine as
+        # name-based checks were already done; we do need to pass the
+        # value ($data) along to allow value-based ignore_values to work.
+        $data = $c->_scrub_value($conf, $data)
+            if $c->_should_scrub_param($conf, '', $data);
     }
 }
 
@@ -133,7 +136,7 @@ sub _scrub_value {
 }
 
 sub _should_scrub_param {
-    my ($c, $conf, $param) = @_;
+    my ($c, $conf, $param, $value) = @_;
     # If we only want to operate on certain params, do that checking
     # now...
     if ($conf && $conf->{ignore_params}) {
@@ -146,6 +149,22 @@ sub _should_scrub_param {
                 return if $param =~ $ignore_param;
             } else {
                 return if $param eq $ignore_param;
+            }
+        }
+    }
+
+    # For cases where there are legitimate values that HTML::Scrubber will
+    # munge... one example was an API where e.g. `<:100' would be eaten.
+    # To allow any param where a `<` is not followed by a `>` in the same
+    # param you could use qr{<[^]+$} or similar.
+    if ($conf && $conf->{ignore_values}) {
+        my $ignore_values = $conf->{ignore_values};
+        if (ref $ignore_values ne 'ARRAY') {
+            $ignore_values = [ $ignore_values ];
+        }
+        for my $ignore_value (@$ignore_values) {
+            if ($value =~ $ignore_value) {
+                return;
             }
         }
     }

--- a/t/03_params.t
+++ b/t/03_params.t
@@ -58,7 +58,18 @@ use Test::More;
         'HTML left alone in ignored (by name) field',
     );
 }
-
+{
+    diag "HTML-ish looking but left alone by ignore_values";
+    my $value = '\<:100';
+    my $req = POST('/', [htmlish => $value]);
+    my ($res, $c) = ctx_request($req);
+    is($res->code, RC_OK, 'response ok');
+    is(
+        $c->req->param('htmlish'),
+        $value,
+        'HTML-ish value left alone in field matching ignore_values pattern',
+    );
+}
 {
     # Test that data in a JSON body POSTed gets scrubbed too
     my $json_body = <<JSON;

--- a/t/lib/MyApp03.pm
+++ b/t/lib/MyApp03.pm
@@ -20,6 +20,8 @@ __PACKAGE__->config(
             qr{/all_exempt/.+},
         ],
 
+        ignore_values => [ qr{^\\<:\d+$} ],
+
         # params for HTML::Scrubber
         params => [
             allow => [qw/br hr b/],


### PR DESCRIPTION
Adds a new option, `ignore_values`, which allows exempting values from
scrubbing by regex matches, for cases where certain HTML-ish values
would have been mangled, but whitelisting parameter names is too
inflexible.

An example API that had this problem allowed various filtering options
on various attributes, and some used syntax like `\<:500` or `\>:500`
for less-than a value or more-than a value - the former was being eaten
by HTML::Scrubber (even though there's no closing `>`).

This new option allows matching such expected and allowed "HTML-ish"
values and exempting them from scrubbage.